### PR TITLE
Fix continue_prediction for scans with period

### DIFF
--- a/nnunetv2/inference/predict_tissue.py
+++ b/nnunetv2/inference/predict_tissue.py
@@ -329,7 +329,8 @@ class TissueNNUnetPredictor(nnUNetPredictor):
             predictions = [p.stem for p in predictions]
 
             for wp in wsi_paths:
-                filename = os.path.basename(wp).split('.')[0]
+                #filename = os.path.basename(wp).split('.')[0]
+                filename = Path(wp).stem
                 if not filename in predictions:
                     files_for_inference.append(wp)
 


### PR DESCRIPTION
Originally, the filename without suffix is extracted with the line:

`filename = os.path.basename(wp).split('.')[0]`

However, this fails for any path with a period in the filename. A safer option is using pathlib's Path(p).stem

`filename = Path(wp).stem`